### PR TITLE
Tasks should return !Log.HasLoggedErrors

### DIFF
--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
@@ -32,10 +32,12 @@ namespace AppSettingStronglyTyped
             var (success, settings) = ReadProjectSettingFiles();
             if (!success)
             {
-                return success;
+                return !Log.HasLoggedErrors;
             }
             //Create the class based on the Dictionary
-            return CreateSettingClass(settings);
+            success = CreateSettingClass(settings);
+
+            return !Log.HasLoggedErrors;
         }
 
         private (bool, IDictionary<string, object>) ReadProjectSettingFiles()


### PR DESCRIPTION
The API allows returning `false`, indicating failure, without indicating
to the user what went wrong. This is terrible! The pattern that we
recommend instead is to always return `!Log.HasLoggedErrors`, and log
an error in bad cases (you were already doing that ≡ƒæì≡ƒÅ╗).
