### PR TITLE
Use Log.LogErrorFromException

### DIFF
--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
@@ -125,9 +125,9 @@ namespace AppSettingStronglyTyped
                 File.WriteAllText(ClassNameFile, settingsClass.ToString());
 
             }
-            catch (Exception Ex)
+            catch (Exception ex)
             {
-                Log.LogError(Ex.ToString());
+                Log.LogErrorFromException(ex, showStackTrace: true);
                 return false;
             }
             return true;


### PR DESCRIPTION
This logging helper method is designed to capture and display
information from arbitrary exceptions in a standard way.
