### PR TITLE
Better errors in AppSettingStronglyTyped

### DIFF
--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
@@ -49,7 +49,7 @@ namespace AppSettingStronglyTyped.Test
         {
             //arrange
             var item = new Mock<ITaskItem>();
-            item.Setup(x => x.GetMetadata("Identity")).Returns(".\\Resources\\error-prop.setting");
+            item.Setup(x => x.GetMetadata("FullPath")).Returns(".\\Resources\\error-prop.setting");
             var appSettingStronglyTyped = new AppSettingStronglyTyped { SettingClassName = "ErrorPropSetting", SettingNamespaceName = "MyNamespace", SettingFiles = new[] { item.Object } };
             appSettingStronglyTyped.BuildEngine = buildEngine.Object;
 
@@ -68,7 +68,7 @@ namespace AppSettingStronglyTyped.Test
         {
             //arrange
             var item = new Mock<ITaskItem>();
-            item.Setup(x => x.GetMetadata("Identity")).Returns(".\\Resources\\notvalidtype-prop.setting");
+            item.Setup(x => x.GetMetadata("FullPath")).Returns(".\\Resources\\notvalidtype-prop.setting");
             var appSettingStronglyTyped = new AppSettingStronglyTyped { SettingClassName = "ErrorPropSetting", SettingNamespaceName = "MyNamespace", SettingFiles = new[] { item.Object } };
             appSettingStronglyTyped.BuildEngine = buildEngine.Object;
 
@@ -87,7 +87,7 @@ namespace AppSettingStronglyTyped.Test
         {
             //arrange
             var item = new Mock<ITaskItem>();
-            item.Setup(x => x.GetMetadata("Identity")).Returns(".\\Resources\\notvalidvalue-prop.setting");
+            item.Setup(x => x.GetMetadata("FullPath")).Returns(".\\Resources\\notvalidvalue-prop.setting");
             var appSettingStronglyTyped = new AppSettingStronglyTyped { SettingClassName = "ErrorPropSetting", SettingNamespaceName = "MyNamespace", SettingFiles = new[] { item.Object } };
             appSettingStronglyTyped.BuildEngine = buildEngine.Object;
 
@@ -111,7 +111,7 @@ namespace AppSettingStronglyTyped.Test
         {
             //arrange
             var item = new Mock<ITaskItem>();
-            item.Setup(x => x.GetMetadata("Identity")).Returns($".\\Resources\\{value}-prop.setting");
+            item.Setup(x => x.GetMetadata("FullPath")).Returns($".\\Resources\\{value}-prop.setting");
             var appSettingStronglyTyped = new AppSettingStronglyTyped { SettingClassName = $"My{value}PropSetting", SettingNamespaceName = "MyNamespace", SettingFiles = new[] { item.Object } };
             appSettingStronglyTyped.BuildEngine = buildEngine.Object;
 
@@ -134,7 +134,7 @@ namespace AppSettingStronglyTyped.Test
         {
             //arrange
             var item = new Mock<ITaskItem>();
-            item.Setup(x => x.GetMetadata("Identity")).Returns($".\\Resources\\complete-prop.setting");
+            item.Setup(x => x.GetMetadata("FullPath")).Returns($".\\Resources\\complete-prop.setting");
             var appSettingStronglyTyped = new AppSettingStronglyTyped { SettingClassName = $"MyCompletePropSetting", SettingNamespaceName = "MyNamespace", SettingFiles = new[] { item.Object } };
             appSettingStronglyTyped.BuildEngine = buildEngine.Object;
 

--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
@@ -60,7 +60,13 @@ namespace AppSettingStronglyTyped.Test
             Assert.IsFalse(success);
             Assert.AreEqual(errors.Count, 1);
             Assert.AreEqual(null, appSettingStronglyTyped.ClassNameFile);
-            Assert.AreEqual("Incorrect line format. Valid format prop:type:defaultvalue", errors.First().Message);
+
+            Assert.AreEqual(1, errors.Count);
+
+            var error = errors.First();
+
+            Assert.AreEqual("Incorrect line format. Valid format prop:type:defaultvalue", error.Message);
+            Assert.AreEqual(1, error.LineNumber);
         }
 
         [TestMethod]

--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
@@ -45,8 +45,8 @@ namespace AppSettingStronglyTyped
             var values = new Dictionary<string, object>();
             foreach (var item in SettingFiles)
             {
-                var identity = item.GetMetadata("Identity");
-                foreach (string line in File.ReadLines(identity))
+                var settingFile = item.GetMetadata("FullPath");
+                foreach (string line in File.ReadLines(settingFile))
                 {
                     var lineParse = line.Split(':');
                     if (lineParse.Length != 3)

--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.cs
@@ -45,13 +45,25 @@ namespace AppSettingStronglyTyped
             var values = new Dictionary<string, object>();
             foreach (var item in SettingFiles)
             {
+                int lineNumber = 0;
+
                 var settingFile = item.GetMetadata("FullPath");
                 foreach (string line in File.ReadLines(settingFile))
                 {
+                    lineNumber++;
+
                     var lineParse = line.Split(':');
                     if (lineParse.Length != 3)
                     {
-                        Log.LogError("Incorrect line format. Valid format prop:type:defaultvalue");
+                        Log.LogError(subcategory: null,
+                                     errorCode: "APPS0001",
+                                     helpKeyword: null,
+                                     file: settingFile,
+                                     lineNumber: lineNumber,
+                                     columnNumber: 0,
+                                     endLineNumber: 0,
+                                     endColumnNumber: 0,
+                                     message: "Incorrect line format. Valid format prop:type:defaultvalue");
                         return (false, null);
                     }
                     var value = GetValue(lineParse[1], lineParse[2]);


### PR DESCRIPTION
Improve error reporting by using the full path to the file and reporting a line number (where it's easy).

Example output:

```sh-session
❯ msbuild .\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild
Microsoft (R) Build Engine version 17.2.0-preview-22081-04+288ea72fc for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 2/16/2022 10:23:24 AM.
Project "S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild" on node 1 (default targets).
S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\error-prop.setting(1): error APPS0001: Incorrect line format. Valid format prop:type:defaultvalue [S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild]
Done Building Project "S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild" (default targets) -- FAILED.


Build FAILED.

"S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild" (default target) (1) ->
(generateSettingClass target) ->
  S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\error-prop.setting(1): error APPS0001: Incorrect line format. Valid format prop:type:defaultvalue [S:\work\msbuild-examples\custom-task-code-generation\AppSettingStronglyTyped\AppSettingStronglyTyped.Test\bin\Debug\net6.0\Resources\testscript-fail.msbuild]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:00.03
```