### PR TITLE
Simplify test projects

### DIFF
--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/Resources/testscript-fail.msbuild
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/Resources/testscript-fail.msbuild
@@ -1,8 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
 	<UsingTask TaskName="AppSettingStronglyTyped.AppSettingStronglyTyped" AssemblyFile="..\AppSettingStronglyTyped.dll" />
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-	</PropertyGroup>
 
 	<PropertyGroup>
 		<SettingClass>MySettingFail</SettingClass>
@@ -10,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<SettingFiles Include="notvalidtype-prop.setting" />
+		<SettingFiles Include="error-prop.setting" />
 	</ItemGroup>
 
 	<Target Name="generateSettingClass">

--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/Resources/testscript-success.msbuild
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/Resources/testscript-success.msbuild
@@ -1,8 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
 	<UsingTask TaskName="AppSettingStronglyTyped.AppSettingStronglyTyped" AssemblyFile="..\AppSettingStronglyTyped.dll" />
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-	</PropertyGroup>
 
 	<PropertyGroup>
 		<SettingClass>MySettingSuccess</SettingClass>


### PR DESCRIPTION
Since the test projects were running only an isolated target, they don't
need to be full SDK projects and can be simplified.
