### PR TITLE
Disable node reuse in integration tests

### DIFF
--- a/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedIntegrationTest.cs
+++ b/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedIntegrationTest.cs
@@ -37,7 +37,7 @@ namespace AppSettingStronglyTyped.Test
         public void ValidSettingTextFile_SettingClassGenerated()
         {
             //Arrage
-            buildProcess.StartInfo.Arguments = "build .\\Resources\\testscript-success.msbuild /t:generateSettingClass";
+            buildProcess.StartInfo.Arguments = "build -nodeReuse:false .\\Resources\\testscript-success.msbuild /t:generateSettingClass";
 
             //Act
             ExecuteCommandAndCollectResults();
@@ -55,7 +55,7 @@ namespace AppSettingStronglyTyped.Test
         public void NotValidSettingTextFile_SettingClassNotGenerated()
         {
             //Arrage
-            buildProcess.StartInfo.Arguments = "build .\\Resources\\testscript-fail.msbuild /t:generateSettingClass";
+            buildProcess.StartInfo.Arguments = "build -nodeReuse:false .\\Resources\\testscript-fail.msbuild /t:generateSettingClass";
 
             //Act
             ExecuteCommandAndCollectResults();


### PR DESCRIPTION
MSBuild starts worker nodes when building multiple projects. These are independent
processes that can be long-lived (by default, they have a 15 minute idle timeout).

Reusing these processes allows subsequent builds to benefit from reduced startup
time and increased caching in internal mechanisms, BUT it also means that there
will be a process holding a lock on any used task assemblies for a long time.

The command-line argument -nodeReuse:false tells MSBuild not to do that: any
additional processes it creates will exit when the build does.

If you've ever noticed builds failing because of a failure to copy to the output
because a file was in use after running tests, it's because of this.
